### PR TITLE
TXL-183: Improved robustness of code for retrieving existing Analytics User ID from a different channel of the same program.

### DIFF
--- a/src/DesktopAnalytics/Analytics.cs
+++ b/src/DesktopAnalytics/Analytics.cs
@@ -54,8 +54,6 @@ namespace DesktopAnalytics
 		/// <param name="userInfo">Information about the user that you have previous collected</param>
 		/// <param name="propertiesThatGoWithEveryEvent">A set of key-value pairs to send with *every* event</param>
 		/// <param name="allowTracking">If false, this will not do any communication with segment.io</param>
-		/// <param name="companyName">If non-null, this will be used (if needed) to locate existing config
-		/// files from previous versions</param>
 		public Analytics(string apiSecret, UserInfo userInfo, Dictionary<string, string> propertiesThatGoWithEveryEvent, bool allowTracking = true)
 		{
 			if (_singleton != null)
@@ -91,7 +89,7 @@ namespace DesktopAnalytics
 				// We really want to use the same ID if possible to keep our statistics valid.
 				try
 				{
-					AttemptToGetUserIdSettingsPromDifferentChannel();
+					AttemptToGetUserIdSettingsFromDifferentChannel();
 				}
 				catch (Exception)
 				{
@@ -165,7 +163,7 @@ namespace DesktopAnalytics
 
 		}
 
-		private void AttemptToGetUserIdSettingsPromDifferentChannel()
+		private void AttemptToGetUserIdSettingsFromDifferentChannel()
 		{
 			// We need to get the company name and exe name of the main application, without introducing a dependency on
 			// Windows.Forms, so we can't use the Windows.Forms.Application methods. For maximum robustness, we try two

--- a/src/DesktopAnalytics/Analytics.cs
+++ b/src/DesktopAnalytics/Analytics.cs
@@ -173,7 +173,7 @@ namespace DesktopAnalytics
 			// REVIEW: The first approach will NOT work for plugins or calls from unmanaged code, but for maximum
 			// compatibility (to keep from breaking Bloom), we try it first. If it fails, we try the second approach,
 			// which should work for everyone (though until there is a plugin that supports channels, it will presumably
-			// never actually find a pre-existing config file from a different channel.
+			// never actually find a pre-existing config file from a different channel).
 
 			string settingsLocation;
 			string productExe;

--- a/src/DesktopAnalytics/DesktopAnalytics.csproj
+++ b/src/DesktopAnalytics/DesktopAnalytics.csproj
@@ -59,6 +59,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
This prevents crash (null reference exception) when GetEntryAssembly returns null and generally prevents any failure in this code from throwing a fatal exception. The new code actually tries two different approaches. The first approach will NOT work for plugins or calls from unmanaged code, but for maximum compatibility (to keep from breaking Bloom), we try it first. If it fails, we try the second approach, which should work for everyone (though until there is a plugin that supports channels, it will presumably never actually find a pre-existing config file from a different channel).